### PR TITLE
chore: add docstrings and docs folder with crash course and advanced usage

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,0 +1,198 @@
+# Advanced Usage
+
+This guide covers patterns for users who want more control than the crash course provides.
+
+---
+
+## The column registry
+
+Instead of defining a `columns` dict inline, you can register column definitions as decorated functions. This is useful when you want to share column definitions across multiple simulations or modules.
+
+```python
+import uuid
+import random
+from kroft.core.registry import register_column, get_registered_columns
+
+@register_column(name="id", sql_type="UUID", constraints="PRIMARY KEY")
+def id_gen():
+    return str(uuid.uuid4())
+
+@register_column(name="updated_at", sql_type="TIMESTAMP", protected=True)
+def updated_at_gen():
+    return "now()"
+
+@register_column(name="product", sql_type="TEXT")
+def product_gen():
+    return random.choice(["bag", "jacket", "cap"])
+
+@register_column(name="unit_price", sql_type="FLOAT")
+def unit_price_gen():
+    return round(random.uniform(20.0, 200.0), 2)
+
+# Reserved — excluded from initial schema, available for evolution
+@register_column(name="category", sql_type="TEXT", reserved=True)
+def category_gen():
+    return random.choice(["clothing", "accessory", "footwear"])
+```
+
+Build your `SchemaManager` and `BatchGenerator` from the registry:
+
+```python
+from kroft import SchemaManager, BatchGenerator
+import psycopg2
+
+columns = get_registered_columns()
+conn = psycopg2.connect("dbname=kroft_test user=postgres host=localhost")
+
+manager = SchemaManager(conn, "public", "orders", columns)
+manager.drop_table()
+manager.create_table()
+
+generator = BatchGenerator(use_registry=True)
+```
+
+The registry is global per process. If you run multiple simulations in the same process, call `get_registered_columns()` once and pass the result explicitly to avoid cross-contamination.
+
+---
+
+## Dynamically registering columns at runtime
+
+You can add a new column to a live `SchemaManager` without restarting:
+
+```python
+from kroft import ColumnDefinition
+
+new_col = ColumnDefinition("promo_code", "TEXT", lambda: "NONE", reserved=True)
+added = manager.register_column("promo_code", new_col)
+
+if added:
+    print("promo_code is now available for schema evolution")
+```
+
+`register_column` returns `False` if the name already exists — it will not overwrite.
+
+---
+
+## Rolling your own simulation loop
+
+`SimulationRunner` is a convenience wrapper. For full control — custom mutation ratios, conditional evolution, per-batch logging — drive the components directly:
+
+```python
+from kroft import SchemaManager, BatchGenerator, MutationEngine, EvolutionController
+import psycopg2, uuid, random
+
+conn = psycopg2.connect("dbname=kroft_test user=postgres host=localhost")
+
+# ... define columns, manager, generator, engine, controller as usual ...
+
+for batch_num in range(1, 51):
+    # Always refresh schema in case evolution added a column
+    generator.schema = manager.get_active_columns()
+
+    rows = generator.generate_batch(batch_size=200)
+    inserted_ids = engine.insert_batch(rows)
+
+    # First 10 batches: insert only
+    if batch_num <= 10:
+        pass
+
+    # Batches 11–30: insert + update
+    elif batch_num <= 30:
+        engine.update_batch(inserted_ids, fraction=0.25, probability=0.9)
+
+    # Batches 31+: full CRUD
+    else:
+        engine.update_batch(inserted_ids, fraction=0.2, probability=0.9)
+        engine.delete_batch(inserted_ids, fraction=0.05, probability=0.5)
+
+    # Schema evolution every 10 batches
+    if batch_num % 10 == 0:
+        result = controller.evolve(batch_num)
+        if result:
+            print(f"Batch {batch_num}: {result}")
+
+print(engine.get_counters())
+print(controller.summary())
+```
+
+This pattern is useful when your simulation has distinct phases — e.g. a backfill period followed by steady-state CDC traffic.
+
+---
+
+## Using SimulationRunner
+
+For simpler use cases, `SimulationRunner` handles the loop for you. It calls `insert_batch`, `maybe_mutate_batch`, and `controller.evolve` on every batch.
+
+```python
+from kroft import SimulationRunner, EvolutionController
+
+controller = EvolutionController(
+    manager=manager,
+    evolution_interval=10,
+    evolution_probability=0.5,
+    max_additions=3,
+    max_drops=1,
+)
+
+runner = SimulationRunner(
+    schema_mgr=manager,
+    mutator=engine,
+    evolution_controller=controller,
+    total_records=10_000,
+    batch_size=500,
+)
+
+runner.run()
+print(engine.get_counters())
+```
+
+`SimulationRunner` uses `maybe_mutate_batch` with its defaults — 50% chance of mutation, 20% update fraction, 10% delete fraction, updates and deletes both enabled. To change this behaviour, roll your own loop.
+
+---
+
+## Configuring logging
+
+Kroft uses Python's standard `logging` module under the `kroft` namespace. By default nothing is printed — wire up a handler to see what's happening:
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+```
+
+To see only Kroft's output without affecting the rest of your application:
+
+```python
+import logging
+
+logger = logging.getLogger("kroft")
+logger.setLevel(logging.DEBUG)
+
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("[%(levelname)s] %(name)s: %(message)s"))
+logger.addHandler(handler)
+logger.propagate = False
+```
+
+Relevant log levels:
+- `DEBUG` — per-operation detail (which mutation operation was picked, how many records affected)
+- `INFO` — schema evolution events from `SimulationRunner`
+
+---
+
+## Inspecting schema history
+
+`SchemaManager` keeps a full version history of which columns were active at each schema version:
+
+```python
+print(manager.schema_version)     # e.g. 3
+print(manager.schema_history)
+# [{"id", "item", "price", "updated_at"},       # v1 — initial
+#  {"id", "item", "price", "updated_at", "discount"},  # v2 — added discount
+#  {"id", "item", "updated_at", "discount"}]    # v3 — dropped price
+```
+
+This is useful for replaying or auditing what the schema looked like at any point in the simulation.

--- a/docs/crash-course.md
+++ b/docs/crash-course.md
@@ -190,7 +190,9 @@ print(engine.get_counters())
 Or let Kroft pick randomly between update and delete on each batch:
 
 ```python
-# 80% chance something happens; when it does, 70% update / 30% delete
+# 80% chance something happens; when it does, one operation is picked at
+# random (50/50 update vs delete). If update: affects 20% of the batch.
+# If delete: affects 10% of the batch.
 engine.maybe_mutate_batch(
     inserted_ids,
     probability=0.8,

--- a/docs/crash-course.md
+++ b/docs/crash-course.md
@@ -1,0 +1,262 @@
+# Kroft Crash Course
+
+Kroft generates synthetic data and simulates how that data changes over time — new rows, updates, deletes, and even schema changes. This guide gets you from zero to a working simulation in minutes.
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- A running PostgreSQL instance
+- `pip install kroft psycopg2-binary`
+
+---
+
+## Core idea
+
+Every simulation is built from three things:
+
+1. **A column pool** — what your table looks like, and what values each column produces
+2. **A schema** — the live table in your database
+3. **A mutation engine** — what happens to the data over time
+
+You compose these yourself, which means you only opt into the complexity you need.
+
+---
+
+## Step 1: Define your columns
+
+A `ColumnDefinition` pairs a column name and SQL type with a generator — a zero-argument function that produces a new value on each call.
+
+```python
+import uuid
+import random
+from kroft import ColumnDefinition
+
+columns = {
+    "id": ColumnDefinition(
+        name="id",
+        sql_type="UUID",
+        generator=lambda: str(uuid.uuid4()),
+        constraints="PRIMARY KEY",
+    ),
+    "item": ColumnDefinition(
+        name="item",
+        sql_type="TEXT",
+        generator=lambda: random.choice(["shoes", "shirt", "hat"]),
+    ),
+    "quantity": ColumnDefinition(
+        name="quantity",
+        sql_type="INT",
+        generator=lambda: random.randint(1, 10),
+    ),
+    "price": ColumnDefinition(
+        name="price",
+        sql_type="FLOAT",
+        generator=lambda: round(random.uniform(10.0, 100.0), 2),
+    ),
+    "updated_at": ColumnDefinition(
+        name="updated_at",
+        sql_type="TIMESTAMP",
+        generator=lambda: "now()",
+        protected=True,  # never mutated or dropped
+    ),
+}
+```
+
+Two flags control how Kroft treats a column:
+
+| Flag | Effect |
+|------|--------|
+| `reserved=True` | Excluded from the initial schema; can be added later via schema evolution |
+| `protected=True` | Never chosen for updates, deletes, or schema drops |
+
+---
+
+## Step 2: Create the table
+
+`SchemaManager` takes your column pool and issues DDL against a real database. Only non-reserved columns are included at creation time.
+
+```python
+import psycopg2
+from kroft import SchemaManager
+
+conn = psycopg2.connect("dbname=kroft_test user=postgres host=localhost")
+
+manager = SchemaManager(conn, schema="public", table_name="sales", columns=columns)
+manager.drop_table()   # clean slate
+manager.create_table()
+```
+
+---
+
+## Step 3: Generate a batch
+
+`BatchGenerator` turns your active columns into rows.
+
+```python
+from kroft import BatchGenerator
+
+generator = BatchGenerator(schema=manager.get_active_columns())
+rows = generator.generate_batch(batch_size=100)
+# [{"id": "...", "item": "shoes", "quantity": 3, "price": 42.5, "updated_at": "now()"}, ...]
+```
+
+---
+
+## Step 4: Insert rows
+
+`MutationEngine` writes rows to the database and tracks insert/update/delete counts.
+
+```python
+from kroft import MutationEngine
+
+engine = MutationEngine(
+    conn=conn,
+    schema="public",
+    table_name="sales",
+    primary_key="id",
+    update_column="updated_at",
+    generator=generator,
+)
+
+inserted_ids = engine.insert_batch(rows)
+```
+
+`insert_batch` returns the list of primary key values — you'll need these for updates and deletes.
+
+---
+
+## The four scenarios
+
+### Scenario 1 — Insert only
+
+Keep appending new rows. Nothing else.
+
+```python
+for _ in range(20):
+    generator.schema = manager.get_active_columns()
+    rows = generator.generate_batch(batch_size=100)
+    engine.insert_batch(rows)
+
+print(engine.get_counters())
+# {"total_inserts": 2000, "total_updates": 0, "total_deletes": 0}
+```
+
+---
+
+### Scenario 2 — Insert + Update
+
+Append new rows and update a fraction of previously inserted ones.
+
+```python
+all_ids = []
+
+for _ in range(20):
+    generator.schema = manager.get_active_columns()
+    rows = generator.generate_batch(batch_size=100)
+    inserted_ids = engine.insert_batch(rows)
+    all_ids.extend(inserted_ids)
+
+    # Update 20% of the batch just inserted, always
+    engine.update_batch(inserted_ids, fraction=0.2, probability=1.0)
+
+print(engine.get_counters())
+# {"total_inserts": 2000, "total_updates": 400, "total_deletes": 0}
+```
+
+---
+
+### Scenario 3 — Insert + Update + Delete
+
+Full CRUD — append, update some, delete some. Control the fractions independently.
+
+```python
+for _ in range(20):
+    generator.schema = manager.get_active_columns()
+    rows = generator.generate_batch(batch_size=100)
+    inserted_ids = engine.insert_batch(rows)
+
+    # Update 20% of this batch
+    engine.update_batch(inserted_ids, fraction=0.2, probability=1.0)
+
+    # Delete 10% of this batch (non-overlapping with updates is your responsibility)
+    engine.delete_batch(inserted_ids, fraction=0.1, probability=1.0)
+
+print(engine.get_counters())
+# {"total_inserts": 2000, "total_updates": 400, "total_deletes": 200}
+```
+
+Or let Kroft pick randomly between update and delete on each batch:
+
+```python
+# 80% chance something happens; when it does, 70% update / 30% delete
+engine.maybe_mutate_batch(
+    inserted_ids,
+    probability=0.8,
+    update_fraction=0.2,
+    delete_fraction=0.1,
+    allow_updates=True,
+    allow_deletes=True,
+)
+```
+
+---
+
+### Scenario 4 — Schema evolution
+
+Add or drop columns at runtime while data keeps flowing. Mark columns as `reserved=True` upfront — they sit in the pool but are excluded from the initial table. `EvolutionController` decides when to promote or drop them.
+
+```python
+columns_with_reserved = {
+    **columns,
+    "discount": ColumnDefinition("discount", "FLOAT", lambda: 0.0, reserved=True),
+    "region": ColumnDefinition("region", "TEXT", lambda: random.choice(["NA", "EU", "ASIA"]), reserved=True),
+}
+
+manager = SchemaManager(conn, "public", "sales", columns_with_reserved)
+manager.drop_table()
+manager.create_table()
+```
+
+```python
+from kroft import EvolutionController
+
+controller = EvolutionController(
+    manager=manager,
+    evolution_interval=5,       # consider evolving every 5 batches
+    evolution_probability=0.8,  # 80% chance it actually fires
+    add_probability=0.7,        # when it fires, 70% chance of adding vs dropping
+    max_additions=2,            # add at most 2 columns total
+    max_drops=1,                # drop at most 1 column total
+)
+```
+
+```python
+for batch_num in range(1, 21):
+    generator.schema = manager.get_active_columns()
+    rows = generator.generate_batch(batch_size=100)
+    inserted_ids = engine.insert_batch(rows)
+
+    engine.update_batch(inserted_ids, fraction=0.2, probability=0.8)
+
+    result = controller.evolve(batch_num)
+    if result:
+        print(result)  # e.g. "[v2] Added column: discount"
+
+print(controller.summary())
+```
+
+Schema evolution and mutations are fully independent — mix and match any combination.
+
+---
+
+## Checking your counters
+
+```python
+print(engine.get_counters())
+# {"total_inserts": 2000, "total_updates": 320, "total_deletes": 180}
+
+print(controller.summary())
+# {"schema_version": 3, "adds": 2, "drops": 1, "max_adds": 2, "max_drops": 1, "evolution_log": [...]}
+```

--- a/kroft/core/batch.py
+++ b/kroft/core/batch.py
@@ -4,18 +4,20 @@ from kroft.core.column import ColumnDefinition
 
 
 class BatchGenerator:
+    """Generates synthetic rows from a column schema.
+
+    Args:
+        schema: Dictionary mapping column name to :class:`ColumnDefinition`.
+            Provide this or set ``use_registry=True``.
+        use_registry: If ``True``, loads the schema from the global column
+            registry populated via :func:`~kroft.core.registry.register_column`.
+    """
+
     def __init__(
         self,
         schema: Optional[Dict[str, ColumnDefinition]] = None,
         use_registry: bool = False
     ):
-        """
-        Initialize a batch generator.
-
-        Args:
-            schema: A dictionary of column name -> ColumnDefinition.
-            use_registry: If True, loads schema from the registered column registry.
-        """
         if schema is not None:
             self.schema = schema
         elif use_registry:

--- a/kroft/core/column.py
+++ b/kroft/core/column.py
@@ -2,6 +2,20 @@ from typing import Any, Callable, Optional
 
 
 class ColumnDefinition:
+    """Metadata and generator for a single table column.
+
+    Args:
+        name: Column name as it appears in the database.
+        sql_type: SQL type string (e.g. ``"UUID"``, ``"TEXT"``, ``"FLOAT"``).
+        generator: Zero-argument callable that returns a new value each call.
+        constraints: Optional SQL constraint string appended to the DDL
+            (e.g. ``"PRIMARY KEY"```, ``"NOT NULL"``).
+        reserved: If ``True``, the column is excluded from the initial schema
+            and can be promoted later via schema evolution.
+        protected: If ``True``, the column is never chosen for mutation
+            (updates/deletes) or schema drops.
+    """
+
     def __init__(
         self,
         name: str,
@@ -19,8 +33,10 @@ class ColumnDefinition:
         self.protected = protected
 
     def generate(self) -> Any:
+        """Return a freshly generated value for this column."""
         return self.generator()
 
     def ddl(self) -> str:
+        """Return the DDL fragment for this column (e.g. ``id UUID PRIMARY KEY``)."""
         parts = [self.name, self.sql_type, self.constraints.strip()]
         return " ".join(p for p in parts if p)

--- a/kroft/core/evolution.py
+++ b/kroft/core/evolution.py
@@ -5,6 +5,26 @@ from kroft.core.schema import SchemaManager
 
 
 class EvolutionController:
+    """Controls when and how the table schema evolves during a simulation.
+
+    On each batch, call :meth:`evolve` — it decides probabilistically whether
+    to promote a reserved column (add) or drop a non-protected one, subject
+    to the configured limits.
+
+    Args:
+        manager: The :class:`~kroft.core.schema.SchemaManager` whose schema
+            this controller will evolve.
+        evolution_interval: Only consider evolving every N batches.
+        evolution_probability: Probability of evolution firing when the
+            interval is reached (0.0–1.0).
+        add_probability: When evolution fires and both add and drop are
+            possible, probability of choosing add over drop (0.0–1.0).
+        max_additions: Maximum number of columns that can be added over the
+            lifetime of the simulation.
+        max_drops: Maximum number of columns that can be dropped over the
+            lifetime of the simulation.
+    """
+
     def __init__(
         self,
         manager: SchemaManager,

--- a/kroft/core/mutator.py
+++ b/kroft/core/mutator.py
@@ -11,6 +11,27 @@ logger = logging.getLogger(__name__)
 
 
 class MutationEngine:
+    """Performs insert, update, and delete operations against a live table.
+
+    Supports four composable simulation scenarios:
+
+    - **Insert only** — call :meth:`insert_batch` and nothing else.
+    - **Insert + Update** — call :meth:`insert_batch` then :meth:`update_batch`.
+    - **Insert + Update + Delete** — chain all three methods.
+    - **Probabilistic mutations** — use :meth:`maybe_mutate_batch` with
+      configurable probability and fraction parameters.
+
+    Args:
+        conn: A live ``psycopg2`` connection.
+        schema: PostgreSQL schema name (e.g. ``"public"``).
+        table_name: Target table name.
+        primary_key: Name of the primary key column. Defaults to ``"id"``.
+        update_column: Optional timestamp column set to ``now()`` on every
+            update (e.g. ``"updated_at"``).
+        generator: :class:`BatchGenerator` used to produce replacement values
+            during updates. Required for update operations.
+    """
+
     def __init__(
         self,
         conn,

--- a/kroft/core/runner.py
+++ b/kroft/core/runner.py
@@ -12,6 +12,22 @@ logger = logging.getLogger(__name__)
 
 
 class SimulationRunner:
+    """Orchestrates a full data simulation: generate batches, mutate, evolve.
+
+    Composes :class:`~kroft.core.schema.SchemaManager`,
+    :class:`~kroft.core.mutator.MutationEngine`, and
+    :class:`~kroft.core.evolution.EvolutionController` into a single
+    run loop. For finer-grained control over mutations or evolution, drive
+    each component directly instead.
+
+    Args:
+        schema_mgr: Manages the table schema and active columns.
+        mutator: Handles insert, update, and delete operations.
+        evolution_controller: Decides when and how to evolve the schema.
+        total_records: Total number of rows to generate across all batches.
+        batch_size: Number of rows per batch.
+    """
+
     def __init__(
         self,
         schema_mgr: SchemaManager,

--- a/kroft/core/schema.py
+++ b/kroft/core/schema.py
@@ -5,6 +5,20 @@ from kroft.core.column import ColumnDefinition
 
 
 class SchemaManager:
+    """Manages the physical database schema for a single table.
+
+    Tracks active vs. reserved columns, issues DDL against the database,
+    and maintains a version history of schema changes.
+
+    Args:
+        conn: A live ``psycopg2`` connection.
+        schema: PostgreSQL schema name (e.g. ``"public"``).
+        table_name: Name of the table to manage.
+        columns: Full column pool — both active and reserved — keyed by
+            column name. Reserved columns are excluded from the initial
+            schema and can be promoted later via :meth:`add_column`.
+    """
+
     def __init__(
         self,
         conn,


### PR DESCRIPTION
## Summary

- Add docstrings to all six public classes: `ColumnDefinition`, `SchemaManager`, `BatchGenerator`, `MutationEngine`, `EvolutionController`, `SimulationRunner`
- Add `docs/crash-course.md` — linear walkthrough of all four simulation scenarios with full working code
- Add `docs/advanced-usage.md` — registry pattern, runtime column registration, custom simulation loops, `SimulationRunner`, logging setup, schema history inspection
- Fix misleading comment on `maybe_mutate_batch` fractions (`update_fraction`/`delete_fraction` are independent batch fractions, not a split ratio)

## Test plan

- [x] All 42 tests pass, lint clean
- [x] Docs reviewed for accuracy against current implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)