### PR TITLE
fix: bump version to 0.1.1 and guard publish against existing PyPI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,26 @@ jobs:
       - name: 🦖 Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: 🔍 Check if version already exists on PyPI
+        id: version_check
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://pypi.org/pypi/kroft/$VERSION/json)
+          if [ "$STATUS" = "200" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Version $VERSION already exists on PyPI — skipping publish."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Version $VERSION not found on PyPI — will publish."
+          fi
+
       - name: 📦 Build package
+        if: steps.version_check.outputs.exists == 'false'
         run: uv build
 
       - name: 🚀 Publish to PyPI
+        if: steps.version_check.outputs.exists == 'false'
         run: uv publish
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kroft"
-version = "0.1.0"
+version = "0.1.1"
 description = "Synthetic data generation and schema evolution simulation for testing data pipelines"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "kroft"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "psycopg2-binary" },


### PR DESCRIPTION
## Summary

- **Version bumped to `0.1.1`** — `0.1.0` was already published to PyPI and cannot be overwritten
- **Publish job now checks PyPI first** — queries `https://pypi.org/pypi/kroft/{version}/json` before building; if the version exists (HTTP 200) it skips publish with a log message instead of failing. This means routine merges that don't bump the version won't break CI.

## How it works

```
GET https://pypi.org/pypi/kroft/0.1.1/json
→ 404: version not published yet → build and publish
→ 200: already published → skip silently
```

## Test plan

- [x] Lint clean, 42 tests pass, 92% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)