### PR TITLE
feat: add seed parameter to SimulationRunner for reproducible runs

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -148,6 +148,26 @@ print(engine.get_counters())
 
 `SimulationRunner` uses `maybe_mutate_batch` with its defaults — 50% chance of mutation, 20% update fraction, 10% delete fraction, updates and deletes both enabled. To change this behaviour, roll your own loop.
 
+### Reproducible runs
+
+Pass `seed` to get the same data and mutation pattern on every run — useful when you need to reproduce a specific failure or share a scenario with a colleague:
+
+```python
+runner = SimulationRunner(
+    schema_mgr=manager,
+    mutator=engine,
+    evolution_controller=controller,
+    total_records=10_000,
+    batch_size=500,
+    seed=42,
+)
+runner.run()  # identical output every time
+```
+
+Omit `seed` (the default) to keep the normal non-deterministic behaviour.
+
+> **Note:** `seed` controls Python's `random` module. If your column generators use `uuid.uuid4()` or `numpy.random`, those are unaffected and will still produce different values each run.
+
 ---
 
 ## Configuring logging

--- a/kroft/core/runner.py
+++ b/kroft/core/runner.py
@@ -2,7 +2,7 @@
 
 import logging
 import random
-from typing import List
+from typing import List, Optional
 
 from kroft.core.evolution import EvolutionController
 from kroft.core.mutator import MutationEngine
@@ -26,6 +26,7 @@ class SimulationRunner:
         evolution_controller: Decides when and how to evolve the schema.
         total_records: Total number of rows to generate across all batches.
         batch_size: Number of rows per batch.
+        seed: Optional integer seed for ``random`` to make runs reproducible.
     """
 
     def __init__(
@@ -35,6 +36,7 @@ class SimulationRunner:
         evolution_controller: EvolutionController,
         total_records: int = 10_000,
         batch_size: int = 500,
+        seed: Optional[int] = None,
     ):
         self.schema_mgr = schema_mgr
         self.mutator = mutator
@@ -42,8 +44,11 @@ class SimulationRunner:
         self.total_records = total_records
         self.batch_size = batch_size
         self.total_batches = total_records // batch_size
+        self.seed = seed
 
     def run(self):
+        if self.seed is not None:
+            random.seed(self.seed)
         for batch_num in range(1, self.total_batches + 1):
             batch = self._generate_batch()
             inserted_ids = self.mutator.insert_batch(batch)

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -123,11 +123,12 @@ def test_simulation_runner_seed_produces_reproducible_runs():
         evolution_controller = MagicMock()
         evolution_controller.evolve.return_value = None
 
-        captured = []
         schema_mgr.columns = {
             "val": ColumnDefinition("val", "FLOAT", lambda: random.uniform(0, 1)),
         }
-        mutator.insert_batch.side_effect = lambda batch: [str(i) for i in range(len(batch))]
+        mutator.insert_batch.side_effect = (
+            lambda batch: [str(i) for i in range(len(batch))]
+        )
 
         runner = SimulationRunner(
             schema_mgr=schema_mgr,
@@ -157,7 +158,9 @@ def test_simulation_runner_no_seed_is_nondeterministic():
         schema_mgr.columns = {
             "val": ColumnDefinition("val", "FLOAT", lambda: random.uniform(0, 1)),
         }
-        mutator.insert_batch.side_effect = lambda batch: [str(i) for i in range(len(batch))]
+        mutator.insert_batch.side_effect = (
+            lambda batch: [str(i) for i in range(len(batch))]
+        )
 
         runner = SimulationRunner(
             schema_mgr=schema_mgr,

--- a/tests/core/test_runner.py
+++ b/tests/core/test_runner.py
@@ -1,3 +1,4 @@
+import random
 from unittest.mock import MagicMock
 
 from kroft.core.column import ColumnDefinition
@@ -113,3 +114,62 @@ def test_simulation_runner_delegates_evolution_to_controller():
     for call_args in evolution_controller.evolve.call_args_list:
         batch_num = call_args[0][0]
         assert batch_num in (1, 2, 3)
+
+
+def test_simulation_runner_seed_produces_reproducible_runs():
+    def make_runner(seed=None):
+        schema_mgr = MagicMock()
+        mutator = MagicMock()
+        evolution_controller = MagicMock()
+        evolution_controller.evolve.return_value = None
+
+        captured = []
+        schema_mgr.columns = {
+            "val": ColumnDefinition("val", "FLOAT", lambda: random.uniform(0, 1)),
+        }
+        mutator.insert_batch.side_effect = lambda batch: [str(i) for i in range(len(batch))]
+
+        runner = SimulationRunner(
+            schema_mgr=schema_mgr,
+            mutator=mutator,
+            evolution_controller=evolution_controller,
+            total_records=10,
+            batch_size=5,
+            seed=seed,
+        )
+        runner.run()
+        return [call[0][0] for call in mutator.insert_batch.call_args_list]
+
+    run1 = make_runner(seed=42)
+    run2 = make_runner(seed=42)
+    run3 = make_runner(seed=99)
+
+    assert run1 == run2
+    assert run1 != run3
+
+
+def test_simulation_runner_no_seed_is_nondeterministic():
+    def make_runner():
+        schema_mgr = MagicMock()
+        mutator = MagicMock()
+        evolution_controller = MagicMock()
+        evolution_controller.evolve.return_value = None
+        schema_mgr.columns = {
+            "val": ColumnDefinition("val", "FLOAT", lambda: random.uniform(0, 1)),
+        }
+        mutator.insert_batch.side_effect = lambda batch: [str(i) for i in range(len(batch))]
+
+        runner = SimulationRunner(
+            schema_mgr=schema_mgr,
+            mutator=mutator,
+            evolution_controller=evolution_controller,
+            total_records=10,
+            batch_size=5,
+        )
+        runner.run()
+        return [call[0][0] for call in mutator.insert_batch.call_args_list]
+
+    # Without a seed, runs should differ (with overwhelming probability)
+    run1 = make_runner()
+    run2 = make_runner()
+    assert run1 != run2 or True  # non-deterministic; just ensure it doesn't crash


### PR DESCRIPTION
## Summary

- Adds an optional `seed: int | None = None` parameter to `SimulationRunner`
- Calls `random.seed(seed)` at the start of `run()` when a seed is provided
- Zero impact on existing users — defaults to `None` (current non-deterministic behaviour)

## Usage

```python
runner = SimulationRunner(
    schema_mgr=...,
    mutator=...,
    evolution_controller=...,
    seed=42,
)
runner.run()  # same output every time
```

## Test plan

- [x] `test_simulation_runner_seed_produces_reproducible_runs` — same seed → identical batches, different seed → different batches
- [x] `test_simulation_runner_no_seed_is_nondeterministic` — unseeded runner doesn't crash
- [x] All 7 existing runner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)